### PR TITLE
Updated deprecated command_line usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,28 +34,30 @@ process = subprocess.Popen([SPEEDTEST_PATH,'--format=json','--precision=4', '--a
 ## HA Configuration and Automation
 * Configure a command_line sensor e.g.: Adjust path and name of the python script to your situation.
 ```
-- platform: command_line
-  name: Speedtest Ping
-  command: "python3.8 /root/speedtest-cli-2ha.py"
-  value_template: "{{ value_json.ping | round(1) }}"
-  command_timeout: 30
-  scan_interval: 1800
-  unit_of_measurement: ms
-  json_attributes:
-    - 'download'
-    - 'upload'
-    - 'server_name'
-    - 'isp'
+command_line:
+  - sensor:
+      name: Speedtest Ping
+      command: "python3.8 /root/speedtest-cli-2ha.py"
+      value_template: "{{ value_json.ping | round(1) }}"
+      command_timeout: 30
+      scan_interval: 1800
+      unit_of_measurement: ms
+      json_attributes:
+        - 'download'
+        - 'upload'
+        - 'server_name'
+        - 'isp'
 ```
 Configure two template sensors to get download and upload speeds from the command_line sensor:
 ```
-- sensor:
-  - name: Speedtest Download
-    state: '{{ state_attr("sensor.speedtest_ping", "download") | round(2) }}'
-    unit_of_measurement: Mbit/s
-  - name: Speedtest Upload
-    state: '{{ state_attr("sensor.speedtest_ping", "upload") | round(2) }}'
-    unit_of_measurement: Mbit/s
+template:
+  - sensor:
+    - name: Speedtest Download
+      state: '{{ state_attr("sensor.speedtest_ping", "download") | round(2) }}'
+      unit_of_measurement: Mbit/s
+    - name: Speedtest Upload
+      state: '{{ state_attr("sensor.speedtest_ping", "upload") | round(2) }}'
+      unit_of_measurement: Mbit/s
 ```
 
 ## Testing and Debugging

--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ Configure two template sensors to get download and upload speeds from the comman
 ```
 template:
   - sensor:
-    - name: Speedtest Download
-      state: '{{ state_attr("sensor.speedtest_ping", "download") | round(2) }}'
-      unit_of_measurement: Mbit/s
-    - name: Speedtest Upload
-      state: '{{ state_attr("sensor.speedtest_ping", "upload") | round(2) }}'
-      unit_of_measurement: Mbit/s
+     - name: Speedtest Download
+       state: '{{ state_attr("sensor.speedtest_ping", "download") | round(2) }}'
+       unit_of_measurement: Mbit/s
+ 
+     - name: Speedtest Upload
+       state: '{{ state_attr("sensor.speedtest_ping", "upload") | round(2) }}'
+       unit_of_measurement: Mbit/s
 ```
 
 ## Testing and Debugging


### PR DESCRIPTION
This method is still valid, however HA has change the usage of command_line sensor. I have also extended the template example to be less confusing about where to put those sensors. 